### PR TITLE
feat: upgrade and reboot os before install k3s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ venv
 .vagrant
 inventory.yml
 playbook/debug.yml
+roles/*.*
+!roles/requirements.yml

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ An odd number of server nodes is required (3,5,7). Read the [official documentat
 
 Setting up a loadbalancer or VIP beforehand to use as the API endpoint is possible but not covered here.
 
+Before we execute the ansible, we need to install all required ansible-galaxy roles
+```bash
+ansible-galaxy install -r roles/requirements.yml
+```
 
 Start provisioning of the cluster using the following command:
 

--- a/playbook/site.yml
+++ b/playbook/site.yml
@@ -1,4 +1,10 @@
 ---
+- name: Upgrade all operating system package and set unattended upgrade
+  hosts: all
+  roles:
+    - role: pescobar.upgrade_all_packages
+      when: ansible_facts['os_family'] == 'Ubuntu' or ansible_facts['os_family'] == 'Debian'
+
 - name: Cluster prep
   hosts: k3s_cluster
   gather_facts: true

--- a/playbook/site.yml
+++ b/playbook/site.yml
@@ -1,5 +1,5 @@
 ---
-- name: Upgrade all operating system package and set unattended upgrade
+- name: Upgrade all operating system packages
   hosts: all
   roles:
     - role: pescobar.upgrade_all_packages

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,0 +1,1 @@
+- src: pescobar.upgrade_all_packages


### PR DESCRIPTION
Before we install the cluster, we need to make sure that all operating system is up to date, including reboot when necessary. To do that, we use role `pescobar.upgrade_all_packages` from ansible-galaxy