### PR TITLE
feat: separate inventory and vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
-markdown
 ## 1.1.0 (2024-03-16)
 - Separated cluster variables from the inventory file into `vars/vars-example.yml` for improved configuration management.
 - Updated Ansible Galaxy role reference from `pescobar` to `akhfa` in `roles/requirements.yml`.
 - Revised README to reflect changes in supported OS and architectures, and added instructions for using the new vars file.
 
-# `k3s-ansible` changelog (`k3s.orchestration`)
 ## 1.0.0
 Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+markdown
+## 1.1.0 (2024-03-16)
+- Separated cluster variables from the inventory file into `vars/vars-example.yml` for improved configuration management.
+- Updated Ansible Galaxy role reference from `pescobar` to `akhfa` in `roles/requirements.yml`.
+- Revised README to reflect changes in supported OS and architectures, and added instructions for using the new vars file.
+
 # `k3s-ansible` changelog (`k3s.orchestration`)
 ## 1.0.0
 Initial Release

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 # Build a Kubernetes cluster using K3s via Ansible
 
 Author: <https://github.com/itwars>  
-Current Maintainer: <https://github.com/dereknola>
+Official Maintainer: <https://github.com/dereknola>
+This Repository Maintainer: <https://github.com/akhfa/>
 
 Easily bring up a cluster on machines running:
 
 - [X] Debian
 - [X] Ubuntu
-- [X] Raspberry Pi OS
-- [X] RHEL Family (CentOS, Redhat, Rocky Linux...)
-- [X] SUSE Family (SLES, OpenSUSE Leap, Tumbleweed...)
-- [X] ArchLinux
 
 on processor architectures:
 
@@ -30,10 +27,11 @@ It is also recommended that all managed nodes disable firewalls and swap. See [K
 
 ## Usage
 
-First copy the sample inventory to `inventory.yml`.
+First copy the sample inventory to `inventory.yml` and vars/vars-example.yml to `vars/vars.yml`
 
 ```bash
 cp inventory-sample.yml inventory.yml
+cp vars/vars-example.yml vars/vars.yml
 ```
 
 Second edit the inventory file to match your cluster setup. For example:
@@ -64,7 +62,7 @@ ansible-galaxy install -r roles/requirements.yml
 Start provisioning of the cluster using the following command:
 
 ```bash
-ansible-playbook playbook/site.yml -i inventory.yml
+ansible-playbook playbook/site.yml -i inventory.yml -e @vars/vars.yml
 ```
 
 ## Upgrading

--- a/inventory-sample.yml
+++ b/inventory-sample.yml
@@ -8,28 +8,3 @@ k3s_cluster:
       hosts:
         192.16.35.12:
         192.16.35.13:
-
-  # Required Vars
-  vars:
-    ansible_port: 22
-    ansible_user: debian
-    k3s_version: v1.26.9+k3s1
-    token: "mytoken"  # Use ansible vault if you want to keep it secret
-    api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
-    extra_server_args: ""
-    extra_agent_args: ""
-
-  # Optional vars
-    # api_port: 6443
-    # k3s_server_location: /var/lib/rancher/k3s
-    # systemd_dir: /etc/systemd/system
-    # extra_service_envs: [ 'ENV_VAR1=VALUE1', 'ENV_VAR2=VALUE2' ]
-    # Manifests or Airgap should be either full paths or relative to the playbook directory.
-    # List of locally available manifests to apply to the cluster, useful for PVCs or Traefik modifications.
-    # extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
-    # airgap_dir: /tmp/k3s-airgap-images
-    # user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
-    # server_config_yaml:  |
-      # This is now an inner yaml file. Maintain the indentation.
-      # YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
-      # See https://docs.k3s.io/installation/configuration#configuration-file

--- a/playbook/site.yml
+++ b/playbook/site.yml
@@ -2,7 +2,7 @@
 - name: Upgrade all operating system packages
   hosts: all
   roles:
-    - role: pescobar.upgrade_all_packages
+    - role: akhfa.upgrade_all_packages
       when: ansible_facts['os_family'] == 'Ubuntu' or ansible_facts['os_family'] == 'Debian'
 
 - name: Cluster prep

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,1 +1,2 @@
+---
 - src: pescobar.upgrade_all_packages

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,2 +1,3 @@
 ---
-- src: akhfa.upgrade_all_packages
+- name: akhfa.upgrade_all_packages
+  src: akhfa.upgrade-all-packages

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,2 +1,2 @@
 ---
-- src: pescobar.upgrade_all_packages
+- src: akhfa.upgrade_all_packages

--- a/vars/.gitignore
+++ b/vars/.gitignore
@@ -1,0 +1,1 @@
+vars.yml

--- a/vars/vars-example.yml
+++ b/vars/vars-example.yml
@@ -1,3 +1,4 @@
+---
 # Required Vars
 ansible_port: 22
 ansible_user: debian

--- a/vars/vars-example.yml
+++ b/vars/vars-example.yml
@@ -3,7 +3,8 @@
 ansible_port: 22
 ansible_user: debian
 k3s_version: v1.26.9+k3s1
-token: "mytoken" # Use ansible vault if you want to keep it secret
+# token -> Use ansible vault if you want to keep it secret
+token: "mytoken"
 api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
 extra_server_args: ""
 extra_agent_args: ""

--- a/vars/vars-example.yml
+++ b/vars/vars-example.yml
@@ -1,0 +1,22 @@
+# Required Vars
+ansible_port: 22
+ansible_user: debian
+k3s_version: v1.26.9+k3s1
+token: "mytoken" # Use ansible vault if you want to keep it secret
+api_endpoint: "{{ hostvars[groups['server'][0]]['ansible_host'] | default(groups['server'][0]) }}"
+extra_server_args: ""
+extra_agent_args: ""
+# Optional vars
+# api_port: 6443
+# k3s_server_location: /var/lib/rancher/k3s
+# systemd_dir: /etc/systemd/system
+# extra_service_envs: [ 'ENV_VAR1=VALUE1', 'ENV_VAR2=VALUE2' ]
+# Manifests or Airgap should be either full paths or relative to the playbook directory.
+# List of locally available manifests to apply to the cluster, useful for PVCs or Traefik modifications.
+# extra_manifests: [ '/path/to/manifest1.yaml', '/path/to/manifest2.yaml' ]
+# airgap_dir: /tmp/k3s-airgap-images
+# user_kubectl: true, by default kubectl is symlinked and configured for use by ansible_user. Set to false to only kubectl via root user.
+# server_config_yaml:  |
+# This is now an inner yaml file. Maintain the indentation.
+# YAML here will be placed as the content of /etc/rancher/k3s/config.yaml
+# See https://docs.k3s.io/installation/configuration#configuration-file


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a separate variables file (`vars/vars-example.yml`) for cluster configuration, improving the manageability of inventory and variables.
- Updated Ansible Galaxy role references from `pescobar` to `akhfa` in `playbook/site.yml` and `roles/requirements.yml`.
- Updated `CHANGELOG.md` and `README.md` to reflect the changes in project structure and usage instructions.
- Simplified the inventory file by removing embedded variables, focusing it solely on inventory.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inventory-sample.yml</strong><dd><code>Simplify Inventory File by Removing Variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

inventory-sample.yml
<li>Removed cluster variables section, focusing the file solely on <br>inventory.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-b2604ab2fac9e93da18b4ba429713dbfc3d5c26d2a3b3c5c73b0c44825652154">+0/-25</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vars-example.yml</strong><dd><code>Introduce Separate Variables File for Cluster Configuration</code></dd></summary>
<hr>

vars/vars-example.yml
<li>Introduced a new file to hold cluster variables previously in the <br>inventory file.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-f9e146e0539eaa50e11a2435f55af767824d3aeb23a42f130489b3d12d55e0fc">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>site.yml</strong><dd><code>Update Role Reference for OS Package Upgrades</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbook/site.yml
<li>Updated role reference from <code>pescobar</code> to <code>akhfa</code> to match new Ansible <br>Galaxy source.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-1e5402b50d4ef5e6b09d73e7c8329db7b969be95ae4081a681f354d1852af6bf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>requirements.yml</strong><dd><code>Align Role Reference with New Ansible Galaxy Source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

roles/requirements.yml
<li>Changed source and added name for <code>upgrade_all_packages</code> role to align <br>with new Ansible Galaxy reference.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-d1b4a44ba6dd817525c78662ffe948ec489372946f29e876a6845b437f2b8eed">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Changes in Version 1.1.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md
<li>Added entry for version 1.1.0 detailing major changes including the <br>separation of variables and inventory files.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with New Maintainer and Usage Instructions</code>&nbsp; </dd></summary>
<hr>

README.md
<li>Updated maintainer information and usage instructions to reflect new <br>vars file.<br> <li> Removed support for certain OS and architectures.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/k3s-ansible/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

